### PR TITLE
chore(appcast): dedupe production + seed staging feed

### DIFF
--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -185,16 +185,6 @@
       </item>
       <item>
         <title>Version 1.0.20</title>
-        <pubDate>Thu, 09 Apr 2026 00:05:34 +0000</pubDate>
-        <sparkle:version>1.0.20</sparkle:version>
-        <sparkle:shortVersionString>1.0.20</sparkle:shortVersionString>
-        <enclosure url="https://github.com/VillaAI/zoryn-releases/releases/download/v1.0.20/Zoryn-1.0.20.dmg"
-          sparkle:edSignature="k67YWQpW9kShhOgC+nsJ05c7bR77stcSpqrHk4WRAQFHrk+cVrofe9CIUinbo/5e8Ig8ZrDFJZ/JNluB1GZFBA=="
-          length="36091068"
-          type="application/octet-stream"/>
-      </item>
-      <item>
-        <title>Version 1.0.20</title>
         <pubDate>Thu, 09 Apr 2026 03:41:58 +0000</pubDate>
         <sparkle:version>1.0.20</sparkle:version>
         <sparkle:shortVersionString>1.0.20</sparkle:shortVersionString>
@@ -251,16 +241,6 @@
         <enclosure url="https://github.com/VillaAI/zoryn-releases/releases/download/v1.0.25/Zoryn-1.0.25.dmg"
           sparkle:edSignature="ue/VzJ7vOe4FURLn4xJ8LPti2YLQC8hMeqKm7DjBgxNZIXKNj3r2XNeS6eN4UpJLYkFxhD1t/LekG6ILkxjmCQ=="
           length="80167459"
-          type="application/octet-stream"/>
-      </item>
-      <item>
-        <title>Version 1.0.26</title>
-        <pubDate>Thu, 16 Apr 2026 05:12:45 +0000</pubDate>
-        <sparkle:version>1.0.26</sparkle:version>
-        <sparkle:shortVersionString>1.0.26</sparkle:shortVersionString>
-        <enclosure url="https://github.com/VillaAI/zoryn-releases/releases/download/v1.0.26/Zoryn-1.0.26.dmg"
-          sparkle:edSignature="HS5HktMo8YTbr/C7RCpP0Aj5x6XDhJmAv0O77QAmQCpedcxozeO/nMMZyh0fRtYqYJXyLnD+W1r3KUy1nvSzCQ=="
-          length="80204570"
           type="application/octet-stream"/>
       </item>
       <item>


### PR DESCRIPTION
## Summary
- **Dedupe production**: removed two pairs of duplicate `<item>` entries in `macos/appcast.xml`.
- **Seed staging**: created `macos/appcast-staging.xml` as a verbatim copy of the cleaned production feed.

## Production cleanup
Two version duplicates blocked `appcast_tool.py validate`:

- **1.0.20**: the earlier (Apr 09 00:05 UTC) entry referenced a 36 MB DMG with a stale signature. The live GitHub asset is 78,649,297 bytes — matches the later (Apr 09 03:41 UTC) entry. **Kept the later one.**
- **1.0.26**: both entries were byte-identical (same URL, length, edSignature, 4 minutes apart). **Kept the later one.**

36 items -> 34 items. No other content touched; ordering, URLs, signatures, and pubDates of all 34 surviving entries are unchanged.

## Staging seed
The new staging-first release flow (`just github-release`) expects `appcast-staging.xml` to exist in the repo. Without it, the recipe currently falls back to copying production into a temp file every run.

Seeded `appcast-staging.xml` once here as a verbatim copy of the cleaned `appcast.xml` so both feeds start aligned. From v1.0.40 onward, `github-release` will append new items to staging; `promote-appcast` will copy them into production.

## Verification
```
$ python3 zoryn/scripts/appcast_tool.py validate macos/appcast.xml macos/appcast-staging.xml
macos/appcast.xml: ok
macos/appcast-staging.xml: ok
```
- 34 `<item>` entries each
- Files byte-identical at this point (`diff -q` clean)

## Test plan
- [ ] Validator passes on both feeds after merge
- [ ] Existing 1.0.20 / 1.0.26 users continue to upgrade through Sparkle (live DMG content unchanged on GitHub)
- [ ] `just github-release` for v1.0.40 succeeds — appends new item to `appcast-staging.xml` only, leaves `appcast.xml` alone
- [ ] `just promote-appcast 1.0.40` then copies the staged item into `appcast.xml`

Generated with [Claude Code](https://claude.com/claude-code)